### PR TITLE
Bump compability to v9

### DIFF
--- a/module.json
+++ b/module.json
@@ -28,7 +28,7 @@
     "manifest": "https://raw.githubusercontent.com/ardittristan/VTTColorSettings/master/module.json",
     "download": "https://github.com/ardittristan/VTTColorSettings/releases/latest/download/colorSettings.zip",
 	"minimumCoreVersion": "0.5.5",
-	"compatibleCoreVersion": "0.8.9",
+	"compatibleCoreVersion": "9",
 	"styles": [
 		"./css/colorpicker.css"
 	]


### PR DESCRIPTION
This mod seems to be working fine in Foundry V9, there are also no tickets currently pending on it connected to v9. I suggest updating the compatibleCoreVersion to get rid of the Compatibility Risk warning